### PR TITLE
Use a relative protocol for Google Fonts

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -8,7 +8,7 @@ $baseurl: '{{ site.baseurl }}/images';
 @import 'libs/functions';
 @import 'libs/mixins';
 @import 'font-awesome.min.css';
-@import url('http://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,600italic,800,800italic');
+@import url('//fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,600italic,800,800italic');
 
 /*
 	Spectral by HTML5 UP


### PR DESCRIPTION
Chrome blocks requesting resources over HTTP from a resource fetched over HTTPS (such as this SCSS file, etc.). Removing the protocol from a URI makes it protocol relative, so Chrome will request the resource using the same protocol as the requesting resource (this file).